### PR TITLE
simple_pdf_extractor.py: update comment on pypdfium2

### DIFF
--- a/use-cases/ai-pdf-information-extraction/api/extraction/simple_pdf_extractor.py
+++ b/use-cases/ai-pdf-information-extraction/api/extraction/simple_pdf_extractor.py
@@ -201,7 +201,7 @@ class SimpleImageExtractor:
         max_pages: Optional[int] = None
     ) -> List[str]:
         """
-        Convert PDF pages to images using pypdfium2 (pure-Python wheels).
+        Convert PDF pages to images using pypdfium2 (self-contained wheels).
         
         Args:
             pdf_path: Path to PDF file
@@ -650,4 +650,5 @@ First, use the extracted text content below. If insufficient, corroborate with t
                     shutil.rmtree(temp_dir)
                     logger.debug(f"Cleaned up temp directory: {temp_dir}")
                 except Exception as e:
+
                     logger.warning(f"Failed to clean up temp directory: {e}")


### PR DESCRIPTION
pypdfium2 is not pure-python (no pure-python PDF rendering engine exists as far as I'm aware).
pypdfium2 does need a binary extension (pdfium), but it is bundled in wheels so they are (virtually) self-contained and do not depend on additional OS packages (unlike e.g. pdf2image which depends on poppler's pdftoppm/pdftocairo).
I guess this is what the commenter meant.